### PR TITLE
Potential fix for code scanning alert no. 14: Shell command built from environment values

### DIFF
--- a/script/rest/update-files.js
+++ b/script/rest/update-files.js
@@ -9,7 +9,7 @@
 import { stat, readFile, writeFile, readdir } from 'fs/promises'
 import path from 'path'
 import program from 'commander'
-import { execSync } from 'child_process'
+import { execSync, execFileSync } from 'child_process'
 import mkdirp from 'mkdirp'
 import rimraf from 'rimraf'
 import getOperations from './utils/get-operations.js'
@@ -100,8 +100,19 @@ async function getDereferencedFiles() {
   )
   try {
     console.log(`bundle -o ${tempDocsDir} ${commandParameters}`)
-    execSync(
-      `${path.join(githubRepoDir, 'bin/openapi')} bundle -o ${tempDocsDir} ${commandParameters}`,
+    // Split commandParameters into an array for use with execFileSync, if not already an array
+    const bundleArgs = [
+      'bundle',
+      '-o',
+      tempDocsDir,
+      // Handle case where commandParameters is a string, e.g. "--foo bar"
+      ...(Array.isArray(commandParameters)
+        ? commandParameters
+        : (commandParameters ? commandParameters.split(' ') : []))
+    ];
+    execFileSync(
+      path.join(githubRepoDir, 'bin/openapi'),
+      bundleArgs,
       { stdio: 'inherit' }
     )
   } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/AlonaHlobina/docs/security/code-scanning/14](https://github.com/AlonaHlobina/docs/security/code-scanning/14)

To fix the problem, rework the `execSync` call (on line 104) to avoid passing a single dynamically constructed string to the shell. Instead, invoke the executable directly with `execFileSync`, providing all parameters as an array, which avoids shell interpretation of spaces or special characters in any argument. This requires changing `execSync` to `execFileSync` (so import or update usage accordingly), changing how the command and arguments are passed, and making sure that `commandParameters` is properly parsed as individual arguments (currently it appears to be a string; if so, split it to an array). Only the code shown in `script/rest/update-files.js` needs to be changed.

Specifically:
- Import `execFileSync` from `child_process` (adjust import as necessary).
- Replace the vulnerable `execSync` call with `execFileSync`, providing the executable as the first argument and an array of arguments as the second.
- Update the log messages for clarity, if necessary.
- If `commandParameters` is a string, split it appropriately (e.g., by shell words, if applicable) or restructure code to ensure it is always an array.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
